### PR TITLE
DefaultConverter can handle DAM documents

### DIFF
--- a/lib/sinicum/imaging/default_converter.rb
+++ b/lib/sinicum/imaging/default_converter.rb
@@ -13,7 +13,13 @@ module Sinicum
       end
 
       def format
-        ".#{@document[:document][:extension]}" if @document && @document[:document]
+        if @document
+          if @document[:'jcr:content']
+            ".#{@document[:'jcr:content'][:extension]}"
+          elsif @document[:document]
+            ".#{@document[:document][:extension]}"
+          end
+        end
       end
     end
   end

--- a/spec/sinicum/imaging/default_converter_spec.rb
+++ b/spec/sinicum/imaging/default_converter_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+module Sinicum::Imaging
+  describe DefaultConverter do
+    let(:document) {
+      doc = double("document")
+      doc.stub(:'[]').and_return(nil)
+      doc
+    }
+    let(:metadata) { double("metadata") }
+    subject { DefaultConverter.new(nil) }
+
+    before(:each) do
+      subject.document = document
+    end
+
+    it "should return the file extension for a Magnolia 5 document" do
+      document.stub(:'[]').with(:'jcr:content').and_return(metadata)
+      metadata.stub(:'[]').with(:extension).and_return("jpeg")
+
+      subject.format.should eq(".jpeg")
+    end
+
+    it "should return the file extension for a Magnolia 4 document" do
+      document.stub(:'[]').with(:'document').and_return(metadata)
+      metadata.stub(:'[]').with(:extension).and_return("png")
+
+      subject.format.should eq(".png")
+    end
+  end
+end


### PR DESCRIPTION
The current version of the `DefaultConverter` still expected Magnolia 4 DMS-based metadata.
