### PR TITLE
Finds DAM files without fingerprint

### DIFF
--- a/lib/sinicum/imaging/imaging_file.rb
+++ b/lib/sinicum/imaging/imaging_file.rb
@@ -70,12 +70,15 @@ module Sinicum
         else
           path = @path_info.dup
         end
+        @normalized_request_path, @extension, @fingerprint = extract_fingerprint(path)
         if path =~ /^\/dam/
           @workspace = :dam
+          if @extension.present? && !@fingerprint
+            @normalized_request_path << ".#{@extension}"
+          end
         elsif path =~ /^\/dms/
           @workspace = :dms
         end
-        @normalized_request_path, @extension, @fingerprint = extract_fingerprint(path)
         renderer_image = normalized_request_path[
           ::Sinicum::Imaging.path_prefix.size + 1, normalized_request_path.size]
         @renderer = renderer_image[0, renderer_image.index("/")]

--- a/spec/sinicum/imaging/imaging_file_spec.rb
+++ b/spec/sinicum/imaging/imaging_file_spec.rb
@@ -6,7 +6,7 @@ module Sinicum
       context "dam" do
         it "should normalize the path" do
           file = ImagingFile.new("/dam/pa.th/to.jpg")
-          file.normalized_request_path.should eq("/damfiles/default/pa.th/to")
+          file.normalized_request_path.should eq("/damfiles/default/pa.th/to.jpg")
           file.extension.should eq("jpg")
           file.fingerprint.should be nil
         end
@@ -28,7 +28,7 @@ module Sinicum
 
         it "should ignore a possible document repetition if the last two path parts do not match" do
           file = ImagingFile.new("/dam/pa.th/to/tu.jpg")
-          file.normalized_request_path.should eq("/damfiles/default/pa.th/to/tu")
+          file.normalized_request_path.should eq("/damfiles/default/pa.th/to/tu.jpg")
           file.extension.should eq("jpg")
           file.fingerprint.should be nil
         end


### PR DESCRIPTION
The changes in this branch can be merged into master since they fix a problem finding fingerprint-less files from the DAM.

The pull request, however, should stay open as the core issue leading to the different behavior of fingerprint-less files has not been addressed yet.
