### PR TITLE
Clean module names with dashes

### DIFF
--- a/lib/sinicum/jcr/type_translators/component_translator.rb
+++ b/lib/sinicum/jcr/type_translators/component_translator.rb
@@ -17,7 +17,7 @@ module Sinicum
         end
 
         def self.instance_from_template_name(json)
-          class_name = split_template_parts(json).join("/").classify
+          class_name = split_template_parts(json).join("/").gsub("-", "_").classify
           class_name.constantize.new(json_response: json)
         rescue NameError
           nil


### PR DESCRIPTION
Clean Ruby module names for Magnolia modules that contain dashes.