### PR TITLE
Extensions are not shown twice

### DIFF
--- a/lib/sinicum/imaging/imaging.rb
+++ b/lib/sinicum/imaging/imaging.rb
@@ -104,8 +104,7 @@ module Sinicum
             FileUtils.mv(out_file.path, file_rendered)
             FileUtils.chmod(0644, file_rendered)
             RenderResult.new(
-              file_rendered, @doc["jcr:mimeType"],
-              "#{@doc[:fileName]}.#{@doc[:extension]}", fingerprint)
+              file_rendered, @doc["jcr:mimeType"], @doc[:fileName], fingerprint)
           rescue => e
             FileUtils.rm(out_file.path) if File.exist?(out_file.path)
             raise e

--- a/lib/sinicum/imaging/imaging.rb
+++ b/lib/sinicum/imaging/imaging.rb
@@ -38,20 +38,8 @@ module Sinicum
           if convert_file?
             result = perform_conversion
           else
-            format = converter.format
-            mime_type =
-              case format
-              when "gif" then "image/gif"
-              when "png" then "image/png"
-              when "ogv" then "video/ogg"
-              when "mp4" then "video/mp4"
-              when "m4a" then "audio/mp4"
-              when "ogg" then "audio/ogg"
-              when "webm" then "audio/webm"
-              else "image/jpeg"
-              end
             result = RenderResult.new(
-              file_rendered, mime_type,
+              file_rendered, mime_type_for_document,
               "#{@doc[:fileName]}.#{@doc[:extension]}", fingerprint)
           end
         end
@@ -124,6 +112,10 @@ module Sinicum
         rescue => e
           logger.error("Cannot write to tempfile: " + e.to_s)
         end
+      end
+
+      def mime_type_for_document
+        Rack::Mime.mime_type("." + @image.extension)
       end
 
       def convert_file?

--- a/lib/sinicum/jcr/dam/document.rb
+++ b/lib/sinicum/jcr/dam/document.rb
@@ -33,6 +33,10 @@ module Sinicum
           [properties[:fileName], properties[:extension]].join(".") if properties
         end
 
+        def extension
+          properties[:extension] if properties
+        end
+
         def mime_type
           properties[:'jcr:mimeType'] if properties
         end

--- a/spec/sinicum/jcr/node_queries_spec.rb
+++ b/spec/sinicum/jcr/node_queries_spec.rb
@@ -43,7 +43,7 @@ module Sinicum
         end
 
         it "should use no authentication if no user and password is configured" do
-          stub_request(:get, "user:pass@content.dievision.de/sinicum-rest/website/home")
+          stub_request(:get, "content.dievision.de/sinicum-rest/website/home")
             .to_return(body: api_response, headers: { "Content-Type" => "application/json" })
           ApiQueries.configure_jcr = {
             host: "content.dievision.de",


### PR DESCRIPTION
Currently there is a problem, that files have their extensions shown twice.

For example: `@filename="dummy_slider_1.png.png"` which was fine for images, since the browser doesn't care.
But the problem was more severe with files like pdfs: `user_guide.pdf.pdf` will not trigger the expected behaviour in a browser.

Apparently Magnolia saves the extension now already in the filename, so we don't have to add it manually.