### PR TITLE
Image Tags can be localized if enabled in the imaging config

### DIFF
--- a/app/helpers/sinicum/helper_utils.rb
+++ b/app/helpers/sinicum/helper_utils.rb
@@ -107,7 +107,7 @@ module Sinicum
     def image_attributes(image, options)
       attributes = {}
       attributes[:src] = adjust_to_asset_host(image.path(converter: options[:renderer]))
-      attributes[:alt] = image[:subject].present? ? image[:subject] : ""
+      attributes[:alt] = image.alt
       [:width, :height].each do |key|
         if options[key]
           attributes[key] = options[key]

--- a/lib/sinicum/jcr/dam/image.rb
+++ b/lib/sinicum/jcr/dam/image.rb
@@ -12,7 +12,11 @@ module Sinicum
         end
 
         def alt
-          self[:subject] || ""
+          if localized_tags?
+            self[:"subject_#{I18n.locale}"] || self[:"caption_#{I18n.locale}"] || ""
+          else
+            self[:subject] || self[:caption] || ""
+          end
         end
 
         private
@@ -33,6 +37,10 @@ module Sinicum
             value = image_size_converter(converter_name).send(dimension) if converter_name
           end
           value
+        end
+
+        def localized_tags?
+          !!(Sinicum::Imaging.app_from_workspace("dam")['localized_image_tags'])
         end
       end
     end

--- a/lib/sinicum/jcr/dam/image.rb
+++ b/lib/sinicum/jcr/dam/image.rb
@@ -13,9 +13,10 @@ module Sinicum
 
         def alt
           if localized_tags?
-            self[:"subject_#{I18n.locale}"] || self[:"caption_#{I18n.locale}"] || ""
+            self[:"subject_#{I18n.locale}"].presence ||
+              self[:"caption_#{I18n.locale}"].presence || ""
           else
-            self[:subject] || self[:caption] || ""
+            self[:subject].presence || self[:caption].presence || ""
           end
         end
 

--- a/spec/dummy/config/locales/ch.yml
+++ b/spec/dummy/config/locales/ch.yml
@@ -1,0 +1,2 @@
+ch:
+  hello: "Hallo Welt"

--- a/spec/dummy/config/locales/de.yml
+++ b/spec/dummy/config/locales/de.yml
@@ -1,0 +1,2 @@
+de:
+  hello: "Hallo Welt"

--- a/spec/dummy/config/locales/fr.yml
+++ b/spec/dummy/config/locales/fr.yml
@@ -1,0 +1,5 @@
+# Sample localization file for English. Add more files in this directory for other locales.
+# See http://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+
+fr:
+  hello: "Hello world"

--- a/spec/fixtures/api/image_mgnl5.json
+++ b/spec/fixtures/api/image_mgnl5.json
@@ -19,7 +19,10 @@
     "modifier" : "dennis_yuen",
     "creationDate" : "2011-01-31T15:13:15.540+08:00",
     "language" : "English",
-	"subject" : "A subject"
+    "subject" : "A subject",
+  	"subject_en" : "A subject",
+    "subject_de" : "Ein Subjekt",
+    "caption_fr" : "Caption in french"
   },
   "nodes" : {
     "jcr:content" : {

--- a/spec/fixtures/imaging.yml
+++ b/spec/fixtures/imaging.yml
@@ -11,7 +11,7 @@ apps:
     magnolia_prefix: "/dam"
     workspace: "dam"
     node_type: "mgnl:asset"
-
+    localized_image_tags: true
 
 renderer:
 

--- a/spec/sinicum/jcr/dam/image_spec.rb
+++ b/spec/sinicum/jcr/dam/image_spec.rb
@@ -28,8 +28,29 @@ module Sinicum
           end
 
           it "should return an empty string if no subject is given" do
-            allow(subject).to receive(:[]).with(:subject).and_return(nil)
+            allow(subject).to receive(:[]).and_return(nil)
             expect(subject.alt).to eq("")
+          end
+
+          context "localized tags" do
+            before(:example) {
+              allow(subject).to receive(:localized_tags?).and_return(true)
+            }
+
+            it "should take the localized alt attribute from the subject" do
+              I18n.locale = :de
+              expect(subject.alt).to eq("Ein Subjekt")
+            end
+
+            it "should return the caption if no subject is given" do
+              I18n.locale = :fr
+              expect(subject.alt).to eq("Caption in french")
+            end
+
+            it "should return an empty string if no subject is given" do
+              I18n.locale = :ch
+              expect(subject.alt).to eq("")
+            end
           end
         end
 


### PR DESCRIPTION
In order to handle also localized image tags, I added a switch to the app config in `imaging.yml`.

If you set it to `true`, it will look for `subject_(locale)` or `caption_(locale)` to use as an alt tag.