### PR TITLE
Only take the language from a 'language-COUNTRY' locale

### DIFF
--- a/lib/sinicum/jcr/dam/image.rb
+++ b/lib/sinicum/jcr/dam/image.rb
@@ -45,7 +45,7 @@ module Sinicum
         end
 
         def language
-          I18n.locale.to_s[0,2]
+          @language ||= I18n.locale.to_s[0,2]
         end
       end
     end

--- a/lib/sinicum/jcr/dam/image.rb
+++ b/lib/sinicum/jcr/dam/image.rb
@@ -12,9 +12,9 @@ module Sinicum
         end
 
         def alt
-          if localized_tags? && I18n.locale != :en
-            self[:"subject_#{I18n.locale}"].presence ||
-              self[:"caption_#{I18n.locale}"].presence || ""
+          if localized_tags? && language != 'en'
+            self[:"subject_#{language}"].presence ||
+              self[:"caption_#{language}"].presence || ""
           else
             self[:subject].presence || self[:caption].presence || ""
           end
@@ -42,6 +42,10 @@ module Sinicum
 
         def localized_tags?
           !!(Sinicum::Imaging.app_from_workspace("dam")['localized_image_tags'])
+        end
+
+        def language
+          I18n.locale.to_s[0,2]
         end
       end
     end

--- a/spec/dummy/config/locales/fr-BE.yml
+++ b/spec/dummy/config/locales/fr-BE.yml
@@ -1,0 +1,5 @@
+# Sample localization file for English. Add more files in this directory for other locales.
+# See http://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+
+fr-BE:
+  hello: "Hello world"

--- a/spec/sinicum/jcr/dam/image_spec.rb
+++ b/spec/sinicum/jcr/dam/image_spec.rb
@@ -51,6 +51,11 @@ module Sinicum
               expect(subject.alt).to eq("Caption in french")
             end
 
+            it "should only take the language - not the country" do
+              I18n.locale = :'fr-BE'
+              expect(subject.alt).to eq("Caption in french")
+            end
+
             it "should return an empty string if no subject is given" do
               I18n.locale = :ch
               expect(subject.alt).to eq("")


### PR DESCRIPTION
In case of a locale `fr-BE`, it should only take the `fr` part as base for the method name.