### PR TITLE
The middleware redirects also on author

### DIFF
--- a/lib/sinicum/multisite/multisite_middleware.rb
+++ b/lib/sinicum/multisite/multisite_middleware.rb
@@ -42,7 +42,7 @@ module Sinicum
             end
             if env['rack.session'][:multisite_root] && on_root_path?(env['rack.session'][:multisite_root], request.fullpath)
               # Redirect to the fullpath without the root_path for consistency
-              return redirect(request.fullpath.gsub(env['rack.session'][:multisite_root], ''))
+              return redirect(gsub_root_path(env['rack.session'][:multisite_root], request.fullpath))
             end
           end
         end
@@ -63,6 +63,11 @@ module Sinicum
 
       def on_root_path?(root_path, path)
         path.start_with?(root_path) if root_path
+      end
+
+      def gsub_root_path(root_path, path)
+        clean_path = path.gsub(root_path, '')
+        clean_path.empty? ? '/' : clean_path
       end
 
       def adjust_paths(env, root_path)

--- a/lib/sinicum/multisite/multisite_middleware.rb
+++ b/lib/sinicum/multisite/multisite_middleware.rb
@@ -13,6 +13,7 @@ module Sinicum
           if Rails.configuration.x.multisite_production == true
             node = node_from_primary_domain(request.host)
             if node.nil?
+              # Alias domain handling - redirect to the primary domain
               node = node_from_alias_domains(request.host)
               return redirect("#{node[:primary_domain]}#{request.fullpath}") if node
             else
@@ -23,6 +24,8 @@ module Sinicum
             nodes = Sinicum::Jcr::Node.query(:multisite, :sql, query)
             if nodes.empty?
               if env['rack.session'][:multisite_root].nil?
+                # If the root node has not been found, it will check for a matching child node of any root node
+                # The first one will be taken
                 query = "select * from mgnl:page where jcr:path LIKE '/%#{path}'"
                 website_nodes = Sinicum::Jcr::Node.query(:website, :sql, query)
                 website_node = website_nodes.select{ |x| x.path =~ /^\/[a-z]*?#{path}$/ }.first
@@ -33,8 +36,13 @@ module Sinicum
                 end
               end
             else
+              # Node has been found, so the session is set
               node = nodes.first
               env['rack.session'][:multisite_root] = node[:root_node]
+            end
+            if env['rack.session'][:multisite_root] && on_root_path?(env['rack.session'][:multisite_root], request.fullpath)
+              # Redirect to the fullpath without the root_path for consistency
+              return redirect(request.fullpath.gsub(env['rack.session'][:multisite_root], ''))
             end
           end
         end
@@ -53,9 +61,12 @@ module Sinicum
         Sinicum::Jcr::Node.query(:multisite, :sql, query).first
       end
 
+      def on_root_path?(root_path, path)
+        path.start_with?(root_path) if root_path
+      end
+
       def adjust_paths(env, root_path)
         return env if multisite_ignored_path?(env) || root_path.nil?
-        return env if env['PATH_INFO'].start_with?(root_path) && Rails.configuration.x.multisite_production != true
         %w(REQUEST_PATH PATH_INFO REQUEST_URI ORIGINAL_FULLPATH).each do |env_path|
           env[env_path] = "#{root_path}#{env['PATH_INFO']}"
         end

--- a/spec/sinicum/multisite/multisite_middleware_spec.rb
+++ b/spec/sinicum/multisite/multisite_middleware_spec.rb
@@ -40,6 +40,7 @@ module Sinicum
         it "should trigger multisite for a rootnode and a subnode" do
           get '/dievision/home'
           expect(request.path).to eq("/dievision/home")
+          expect(response).to redirect_to("/home")
           expect(request.session[:multisite_root]).to eq("/dievision")
         end
 

--- a/spec/sinicum/multisite/multisite_middleware_spec.rb
+++ b/spec/sinicum/multisite/multisite_middleware_spec.rb
@@ -31,13 +31,14 @@ module Sinicum
           expect(request.session[:multisite_root]).to eq("/dievision")
         end
 
-        it "should trigger multisite for a rootnode" do
+        it "should trigger multisite for a rootnode and redirect" do
           get '/dievision'
           expect(request.path).to eq("/dievision")
+          expect(response).to redirect_to("/")
           expect(request.session[:multisite_root]).to eq("/dievision")
         end
 
-        it "should trigger multisite for a rootnode and a subnode" do
+        it "should trigger multisite for a rootnode and a subnode and redirect" do
           get '/dievision/home'
           expect(request.path).to eq("/dievision/home")
           expect(response).to redirect_to("/home")


### PR DESCRIPTION
I changed the behaviour of the multisite on author/dev.

Previously, if a path - starting with the root_node - was requested, it would just let it pass.
So with `first_node` as root node path, `/first_node/subnode` was a valid path, same as `/subnode`.

Now it will redirect `/root_node/subnode` to `/subnode` and provide more consistency.
Additionally `/root_node` will redirect to `/`.

Also I added some comments to explain the workflow a little.