### PR TITLE
Root Path should not redirect

### DIFF
--- a/lib/sinicum/multisite/multisite_middleware.rb
+++ b/lib/sinicum/multisite/multisite_middleware.rb
@@ -62,7 +62,7 @@ module Sinicum
       end
 
       def on_root_path?(root_path, path)
-        path.start_with?(root_path) if root_path
+        path.start_with?("#{root_path}/") if root_path
       end
 
       def gsub_root_path(root_path, path)
@@ -72,6 +72,7 @@ module Sinicum
 
       def adjust_paths(env, root_path)
         return env if multisite_ignored_path?(env) || root_path.nil?
+        return env if env['PATH_INFO'].start_with?(root_path) && Rails.configuration.x.multisite_production != true
         %w(REQUEST_PATH PATH_INFO REQUEST_URI ORIGINAL_FULLPATH).each do |env_path|
           env[env_path] = "#{root_path}#{env['PATH_INFO']}"
         end

--- a/lib/sinicum/multisite/multisite_middleware.rb
+++ b/lib/sinicum/multisite/multisite_middleware.rb
@@ -62,7 +62,7 @@ module Sinicum
       end
 
       def on_root_path?(root_path, path)
-        path.start_with?("#{root_path}/") if root_path
+        path.match(/^(#{root_path})\//) if root_path
       end
 
       def gsub_root_path(root_path, path)

--- a/spec/sinicum/multisite/multisite_middleware_spec.rb
+++ b/spec/sinicum/multisite/multisite_middleware_spec.rb
@@ -35,6 +35,10 @@ module Sinicum
           get '/dievision'
           expect(request.path).to eq("/dievision")
           expect(request.session[:multisite_root]).to eq("/dievision")
+
+          get '/dievision/'
+          expect(request.path).to eq("/dievision/")
+          expect(request.session[:multisite_root]).to eq("/dievision")
         end
 
         it "should trigger multisite for a rootnode and a subnode and redirect" do

--- a/spec/sinicum/multisite/multisite_middleware_spec.rb
+++ b/spec/sinicum/multisite/multisite_middleware_spec.rb
@@ -31,10 +31,9 @@ module Sinicum
           expect(request.session[:multisite_root]).to eq("/dievision")
         end
 
-        it "should trigger multisite for a rootnode and redirect" do
+        it "should trigger multisite for a rootnode and not redirect" do
           get '/dievision'
           expect(request.path).to eq("/dievision")
-          expect(response).to redirect_to("/")
           expect(request.session[:multisite_root]).to eq("/dievision")
         end
 


### PR DESCRIPTION
If just the root path is requested, it should not redirect in the author/dev environment - otherwise it would be redirected to the Magnolia Admininterface.