### PR TITLE
Honor the asset host configuration

### DIFF
--- a/app/helpers/sinicum/mgnl_image_helper.rb
+++ b/app/helpers/sinicum/mgnl_image_helper.rb
@@ -5,7 +5,7 @@ module Sinicum
 
     def mgnl_asset_path(key_or_object = nil, options = {})
       options[:workspace] = "dam" if options[:workspace].nil?
-      mgnl_path(key_or_object, options)
+      adjust_to_asset_host(mgnl_path(key_or_object, options))
     end
 
     def mgnl_img(key_or_object, options = {})


### PR DESCRIPTION
`mgnl_asset_path` ignored the Rails asset host configuration so far. Since there is an “asset” in the method name, I think it is safe to assume that this should be the case.

If you want a String of only the path and never a URL, use `mgnl_path` instead.