### PR TITLE
Thread local cache

### DIFF
--- a/lib/sinicum.rb
+++ b/lib/sinicum.rb
@@ -52,4 +52,7 @@ module Sinicum
   require 'sinicum/navigation/default_navigation_element'
   require 'sinicum/navigation/navigation_handler'
   require 'sinicum/navigation/navigation_element_list'
+
+  require 'sinicum/cache/thread_local_cache'
+  require 'sinicum/cache/thread_local_cache_middleware'
 end

--- a/lib/sinicum/cache/thread_local_cache.rb
+++ b/lib/sinicum/cache/thread_local_cache.rb
@@ -1,0 +1,56 @@
+module Sinicum
+  module Cache
+    class ThreadLocalCache
+      THREAD_LOCAL_KEY = "#{name}-cache-key"
+      THREAD_LOCAL_ACTIVATION_KEY = "#{THREAD_LOCAL_KEY}-activation"
+
+      def self.put(key, value)
+        cache[key] = value if active?
+        value
+      end
+
+      def self.get(key)
+        cache[key] if active?
+      end
+
+      def self.clear
+        Thread.current[THREAD_LOCAL_KEY] = {}
+      end
+
+      def self.fetch(key, &block)
+        if active? && cache.has_key?(key) && !get(key).nil?
+          get(key)
+        else
+          result = block.call
+          put(key, result)
+          result
+        end
+      end
+
+      def self.active?
+        Thread.current[THREAD_LOCAL_ACTIVATION_KEY] == true
+      end
+
+      def self.enable!
+        Thread.current[THREAD_LOCAL_ACTIVATION_KEY] = true
+      end
+
+      def self.disable!
+        Thread.current[THREAD_LOCAL_ACTIVATION_KEY] = false
+        clear
+        nil
+      end
+
+      private
+
+      def self.cache
+        cache = Thread.current[THREAD_LOCAL_KEY]
+        unless cache
+          cache = {}
+          Thread.current[THREAD_LOCAL_KEY] = cache
+        end
+        cache
+      end
+    end
+  end
+end

--- a/lib/sinicum/cache/thread_local_cache_middleware.rb
+++ b/lib/sinicum/cache/thread_local_cache_middleware.rb
@@ -1,0 +1,19 @@
+module Sinicum
+  module Cache
+    class ThreadLocalCacheMiddleware
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        Sinicum::Cache::ThreadLocalCache.enable!
+        begin
+          status, headers, response = @app.call(env)
+        ensure
+          Sinicum::Cache::ThreadLocalCache.disable!
+        end
+        [status, headers, response]
+      end
+    end
+  end
+end

--- a/lib/sinicum/engine.rb
+++ b/lib/sinicum/engine.rb
@@ -17,16 +17,20 @@ module Sinicum
     end
 
     initializer "sinicum.add_middleware" do |app|
-      app.middleware.insert_after ActionDispatch::Callbacks, Sinicum::Imaging::ImagingMiddleware
+      app.middleware.insert_after ActionDispatch::Callbacks,
+        Sinicum::Cache::ThreadLocalCacheMiddleware
+      app.middleware.insert_after Sinicum::Cache::ThreadLocalCacheMiddleware,
+        Sinicum::Imaging::ImagingMiddleware
       unless app.config.x.multisite_disabled == true
         app.middleware.use Sinicum::Multisite::MultisiteMiddleware
         if app.config.x.multisite_ignored_paths.is_a?(Array)
-          app.config.x.multisite_ignored_paths << /#{Regexp.quote(Rails.configuration.assets.prefix)}/
+          app.config.x.multisite_ignored_paths <<
+            /#{Regexp.quote(Rails.configuration.assets.prefix)}/
         else
-          app.config.x.multisite_ignored_paths = [/#{Regexp.quote(Rails.configuration.assets.prefix)}/]
+          app.config.x.multisite_ignored_paths =
+            [/#{Regexp.quote(Rails.configuration.assets.prefix)}/]
         end
       end
     end
-
   end
 end

--- a/lib/sinicum/jcr/node_queries.rb
+++ b/lib/sinicum/jcr/node_queries.rb
@@ -14,13 +14,17 @@ module Sinicum
         include QuerySanitizer
 
         def find_by_path(workspace, path)
-          url = construct_url(workspace, nil, path)
-          return_first_item(url)
+          Sinicum::Cache::ThreadLocalCache.fetch(["node-path", workspace, path].join("-")) do
+            url = construct_url(workspace, nil, path)
+            return_first_item(url)
+          end
         end
 
         def find_by_uuid(workspace, uuid)
-          url = construct_url(workspace, UUID_PREFIX, uuid)
-          return_first_item(url)
+          Sinicum::Cache::ThreadLocalCache.fetch(["node-uuid", workspace, uuid].join("-")) do
+            url = construct_url(workspace, UUID_PREFIX, uuid)
+            return_first_item(url)
+          end
         end
 
         def query(workspace, language, query, parameters = nil, options = {})

--- a/spec/sinicum/cache/thread_local_cache_spec.rb
+++ b/spec/sinicum/cache/thread_local_cache_spec.rb
@@ -1,0 +1,81 @@
+require "spec_helper"
+
+module Sinicum::Cache
+  describe ThreadLocalCache do
+    context "with activated cache" do
+      around(:example) do |example|
+        ThreadLocalCache.enable!
+        example.run
+        ThreadLocalCache.disable!
+      end
+
+      it "should cache an object" do
+        ThreadLocalCache.put("key", "value")
+
+        expect(ThreadLocalCache.get("key")).to eq("value")
+      end
+
+      it "should return nil if no object is stored" do
+        ThreadLocalCache.put("key", "value")
+
+        expect(ThreadLocalCache.get("another_key")).to be nil
+      end
+
+      it "should clear the cache" do
+        ThreadLocalCache.put("key", "value")
+        ThreadLocalCache.clear
+
+        expect(ThreadLocalCache.get("key")).to be nil
+      end
+
+      it "should store an object via the fetch method" do
+        ThreadLocalCache.fetch("key") do
+          "a value"
+        end
+
+        expect(ThreadLocalCache.get("key")).to eq("a value")
+      end
+
+      it "should fetch an object via the fetch method" do
+        ThreadLocalCache.put("key", "a value")
+        result = ThreadLocalCache.fetch("key") do
+          "another value"
+        end
+
+        expect(result).to eq("a value")
+      end
+
+      it "is thread safe" do
+        ThreadLocalCache.put("key", "a value")
+        result = "something"
+        new = Thread.new do
+          result = ThreadLocalCache.get("key")
+        end
+        new.join
+
+        expect(result).to be nil
+      end
+
+      it "should be activated" do
+        expect(ThreadLocalCache.active?).to be true
+      end
+    end
+
+    context "with cache disabled" do
+      it "should not store anything" do
+        ThreadLocalCache.put("key", "value")
+
+        expect(ThreadLocalCache.get("key")).to be nil
+      end
+
+      it "produce a cache miss with the fetch method" do
+        ThreadLocalCache.put("key", "value")
+        result = ThreadLocalCache.fetch("key") do
+          "another value"
+        end
+
+        expect(result).to eq("another value")
+      end
+    end
+  end
+end


### PR DESCRIPTION
API calls for the same node are cached during the request to prevent repeated calls for the exact same node.