### PR TITLE
A redirect page should not trigger the render from cache

### DIFF
--- a/app/controllers/sinicum/controllers/global_state_cache.rb
+++ b/app/controllers/sinicum/controllers/global_state_cache.rb
@@ -32,7 +32,7 @@ module Sinicum
 
       def render_or_proceed
         cached = Rails.cache.fetch(cache_key)
-        if cached
+        if cached && cached[:status].to_s != "302"
           @controller.response.cache_control.merge!(cached[:cache_control])
           @controller.response.status = cached[:status]
           @controller.response.headers["X-SCache"] = "true"


### PR DESCRIPTION
FIxes the 302 being cached problem for Max-e
Should be merged to master