### PR TITLE
Multisite is a lot cleaner now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ rvm:
   - "2.3.0"
 before_script:
   - export TZ='Europe/Berlin'
-script: bundle exec rake
+script:
+  - bundle exec rake
+after_script:
+  - CODECLIMATE_REPO_TOKEN=97304c6d5e6017ffcf39bb7220a40d37062205ae6b8989a712ac0631b9122111 bundle exec codeclimate-test-reporter
 gemfile:
   - Gemfile
   - gemfiles/Gemfile-4.2
-addons:
-  code_climate:
-    repo_token: 97304c6d5e6017ffcf39bb7220a40d37062205ae6b8989a712ac0631b9122111

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
 script:
   - bundle exec rake
 after_script:
-  - CODECLIMATE_REPO_TOKEN=97304c6d5e6017ffcf39bb7220a40d37062205ae6b8989a712ac0631b9122111 bundle exec codeclimate-test-reporter
+  - CODECLIMATE_REPO_TOKEN=a0a2bb8de1052f04e02943c208909e1ee43feed7 bundle exec codeclimate-test-reporter
 gemfile:
   - Gemfile
   - gemfiles/Gemfile-4.2

--- a/lib/sinicum/multisite/multisite_middleware.rb
+++ b/lib/sinicum/multisite/multisite_middleware.rb
@@ -1,13 +1,12 @@
 module Sinicum
   module Multisite
     class MultisiteMiddleware
-
       def initialize(app)
         @app = app
       end
 
       def call(env)
-        request = Rack::Request.new(env)
+        request = ActionDispatch::Request.new(env)
         path = request.path.gsub(".html", "")
         unless multisite_ignored_path?(env)
           if Rails.configuration.x.multisite_production == true
@@ -20,40 +19,17 @@ module Sinicum
               request.session[:multisite_root] = node[:root_node]
             end
           else # author/dev
-            Rails.logger.info("    Sinicum Multisite: Session =>" \
-              " #{request.session[:multisite_root].inspect}")
-            if request.session[:multisite_root] &&
-                on_root_path?(request.session[:multisite_root], request.fullpath)
+            log("Session => #{request.session[:multisite_root].inspect}")
+            query = "select * from mgnl:multisite where root_node LIKE '#{root_from_path(path)}'"
+            if node = Sinicum::Jcr::Node.query(:multisite, :sql, query).first
+              # Node has been found, so the session is set
+              log("Node has been found - Session => #{node[:root_node].inspect}")
+              request.session[:multisite_root] = node[:root_node]
+            end
+            if on_root_path?(request.session[:multisite_root], request.fullpath)
               # Redirect to the fullpath without the root_path for consistency
-              Rails.logger.info("    Sinicum Multisite: Redirect to the fullpath")
               return redirect(gsub_root_path(
                 request.session[:multisite_root], request.fullpath))
-            end
-            query = "select * from mgnl:multisite where root_node LIKE '#{root_from_path(path)}'"
-            nodes = Sinicum::Jcr::Node.query(:multisite, :sql, query)
-            if nodes.empty?
-              if request.session[:multisite_root].nil?
-                # If the root node has not been found, it will check
-                # for a matching child node of any root node. The first
-                # one will be taken.
-                query = "select * from mgnl:page where jcr:path LIKE '/%#{path}'"
-                website_nodes = Sinicum::Jcr::Node.query(:website, :sql, query)
-                website_node = website_nodes.select{ |x| x.path =~ /^\/[a-zA-Z_-]*?#{%r(path)}$/ }.first
-                if website_node
-                  query = "select * from mgnl:multisite where root_node " \
-                    "LIKE '#{root_from_path(website_node.path)}'"
-                  node = Sinicum::Jcr::Node.query(:multisite, :sql, query).first
-                  Rails.logger.info("    Sinicum Multisite: SubNode has been found - Session =>" \
-                    " #{node[:root_node].inspect}")
-                  request.session[:multisite_root] = node[:root_node]
-                end
-              end
-            else
-              # Node has been found, so the session is set
-              node = nodes.first
-              Rails.logger.info("    Sinicum Multisite: Node has been found - Session =>" \
-                " #{node[:root_node].inspect}")
-              request.session[:multisite_root] = node[:root_node]
             end
           end
         end
@@ -63,6 +39,10 @@ module Sinicum
       end
 
       private
+      def log(msg)
+        Rails.logger.info("  Sinicum Multisite:" + msg) if Rails.configuration.x.multisite_logging
+      end
+
       def node_from_alias_domains(domain)
         Rails.cache.fetch("sinicum-multisite-node-alias-#{domain}", expires: 1.hour) do
           query = "select * from mgnl:multisite where alias_domains LIKE '%//#{domain}%'"
@@ -78,7 +58,7 @@ module Sinicum
       end
 
       def on_root_path?(root_path, path)
-        path.match(/^(#{root_path})\//) if root_path
+        !!(root_path && path.match(/^(#{root_path})\//))
       end
 
       def gsub_root_path(root_path, path)

--- a/sinicum.gemspec
+++ b/sinicum.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('yard')
   s.add_development_dependency('webmock')
   s.add_development_dependency('rubocop')
+  s.add_development_dependency('simplecov')
   s.add_development_dependency('codeclimate-test-reporter')
 
   s.files         = `git ls-files`.split("\n")

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -24,6 +24,8 @@ Dummy::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.cache_store = :null_store
+
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,
   # like if you have constraints or database-specific column types

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,7 @@
 # Configure Rails Envinronment
 ENV["RAILS_ENV"] = "test"
-
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require "simplecov"
+SimpleCov.start
 
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "rspec/rails"


### PR DESCRIPTION
The main change lies in the use of `ActionDispatch::Request` instead of `Rack::Request`.

Since the middleware is inserted after the ActionDispatch Middleware, we can use the more sophisticated Request object from ActionDispatch.

So now the session saves the set value even after an immediate redirect. This means, there will be finally full consistency, when it comes to URLs.
Every URL on a multisite path with the root_node still in it, will be redirected.

Besides this, the bug with the lost session has disappeared too.