### PR TITLE
Title can also be used for the alt tag

### DIFF
--- a/lib/sinicum/jcr/dam/image.rb
+++ b/lib/sinicum/jcr/dam/image.rb
@@ -14,9 +14,11 @@ module Sinicum
         def alt
           if localized_tags? && language != 'en'
             self[:"subject_#{language}"].presence ||
-              self[:"caption_#{language}"].presence || ""
+              self[:"caption_#{language}"].presence || 
+              self[:title].presence || ""
           else
-            self[:subject].presence || self[:caption].presence || ""
+            self[:subject].presence || self[:caption].presence ||
+              self[:title].presence || ""
           end
         end
 

--- a/spec/sinicum/jcr/dam/image_spec.rb
+++ b/spec/sinicum/jcr/dam/image_spec.rb
@@ -58,7 +58,7 @@ module Sinicum
 
             it "should return an empty string if no subject is given" do
               I18n.locale = :ch
-              expect(subject.alt).to eq("")
+              expect(subject.alt).to eq("twitter")
             end
           end
         end


### PR DESCRIPTION
Since it's a standard field from the magnolia assets, it seems plausible to also use it, if the other fields are empty.