### PR TITLE
Redirect for non fingerprinted assets

### DIFF
--- a/lib/sinicum/imaging/imaging_file.rb
+++ b/lib/sinicum/imaging/imaging_file.rb
@@ -22,6 +22,10 @@ module Sinicum
         !!imaging_result
       end
 
+      def fingerprinted?
+        !!fingerprint
+      end
+
       def path
         imaging_result.path
       end
@@ -35,6 +39,15 @@ module Sinicum
           FINGERPRINT_CACHE_TIME
         else
           DEFAULT_CACHE_TIME
+        end
+      end
+
+      def calculated_asset_path
+        @calculated_asset_path ||= begin
+          doc = Sinicum::Jcr::Node.find_by_path(@workspace, @file_asset_path)
+          if doc && doc.is_a?(Sinicum::Jcr::Dam::Document)
+            doc.path(converter: @renderer)
+          end
         end
       end
 


### PR DESCRIPTION
With the current implementation of the imaging middleware, one could resolve an asset with a fingerprinted url or a non-fingerprinted url. Since this is bound to produce caching problems, I've implemented a redirect, if a non-fingerprinted url is called.

The middleware basically checks, if it can find the asset (like before) but then still checks, if a fingerprint can be found. If this was successful - good, serve asset. If the fingerprint wasn't found, it will query the asset from the workspace and redirect to it's fingerprinted path.