### PR TITLE
srcset changes

### DIFF
--- a/app/helpers/sinicum/helper_utils.rb
+++ b/app/helpers/sinicum/helper_utils.rb
@@ -176,17 +176,5 @@ module Sinicum
       attributes_hash
     end
 
-    # #srcset optimization, see http://w3c.github.io/html/semantics-embedded-content.html#element-attrdef-img-srcset
-    # def add_srcset(attributes_hash)
-    #   srcset_options = Sinicum::Imaging::Config.read_configuration.srcset_options
-    #   if srcset_options.present?
-    #     if match = attributes_hash[:src].match(/(.+?)-(\h{32})(\.\w+)?$/)
-    #       attributes_hash[:srcset] = srcset_options.map { |e|  \
-    #         "#{match[1]}_#{e[0]}-#{match[2]}#{match[3]} #{e[1]}"}.join(", ")
-    #     end
-    #   end
-    #   attributes_hash
-    # end
-
   end
 end

--- a/app/helpers/sinicum/helper_utils.rb
+++ b/app/helpers/sinicum/helper_utils.rb
@@ -149,16 +149,44 @@ module Sinicum
       options[:workspace] || DEFAULT_DOCUMENT_WORKSPACE
     end
 
-    #srcset optimization, see http://w3c.github.io/html/semantics-embedded-content.html#element-attrdef-img-srcset
-    def add_srcset(attributes_hash)
+    def original_picture_width(src_attribute)
+      src_splited_path = src_attribute.split("/")
+      renderer = Sinicum::Imaging::Config.read_configuration.renderer["#{src_splited_path[2]}"]
+      renderer["x"]
+    end
+
+    def calculate_resulting_width(srcset_option, original_picture_width)
+      srcset_option = srcset_option[0...-1]
+      result = original_picture_width*srcset_option.to_f
+      result.to_i
+    end
+
+    def configure_for_srcset(attributes_hash)
       srcset_options = Sinicum::Imaging::Config.read_configuration.srcset_options
       if srcset_options.present?
         if match = attributes_hash[:src].match(/(.+?)-(\h{32})(\.\w+)?$/)
           attributes_hash[:srcset] = srcset_options.map { |e|  \
-            "#{match[1]}_#{e[0]}-#{match[2]}#{match[3]} #{e[1]}"}.join(", ")
+            "#{match[1]}_#{e[0]}-#{match[2]}#{match[3]} #{calculate_resulting_width(e[1],
+            original_picture_width(attributes_hash[:src]))}w"}.join(", ")
         end
+        #remove now unnecessary tags
+        attributes_hash.delete(:height)
+        attributes_hash.delete(:width)
       end
       attributes_hash
     end
+
+    # #srcset optimization, see http://w3c.github.io/html/semantics-embedded-content.html#element-attrdef-img-srcset
+    # def add_srcset(attributes_hash)
+    #   srcset_options = Sinicum::Imaging::Config.read_configuration.srcset_options
+    #   if srcset_options.present?
+    #     if match = attributes_hash[:src].match(/(.+?)-(\h{32})(\.\w+)?$/)
+    #       attributes_hash[:srcset] = srcset_options.map { |e|  \
+    #         "#{match[1]}_#{e[0]}-#{match[2]}#{match[3]} #{e[1]}"}.join(", ")
+    #     end
+    #   end
+    #   attributes_hash
+    # end
+
   end
 end

--- a/app/helpers/sinicum/helper_utils.rb
+++ b/app/helpers/sinicum/helper_utils.rb
@@ -149,31 +149,23 @@ module Sinicum
       options[:workspace] || DEFAULT_DOCUMENT_WORKSPACE
     end
 
-    def original_picture_width(src_attribute)
-      src_splited_path = src_attribute.split("/")
-      renderer = Sinicum::Imaging::Config.read_configuration.renderer["#{src_splited_path[2]}"]
-      renderer["x"]
-    end
-
-    def calculate_resulting_width(srcset_option, original_picture_width)
-      srcset_option = srcset_option[0...-1]
-      result = original_picture_width*srcset_option.to_f
-      result.to_i
-    end
-
     def configure_for_srcset(attributes_hash)
       srcset_options = Sinicum::Imaging::Config.read_configuration.srcset_options
       if srcset_options.present?
         if match = attributes_hash[:src].match(/(.+?)-(\h{32})(\.\w+)?$/)
           attributes_hash[:srcset] = srcset_options.map { |e|  \
             "#{match[1]}_#{e[0]}-#{match[2]}#{match[3]} #{calculate_resulting_width(e[1],
-            original_picture_width(attributes_hash[:src]))}w"}.join(", ")
+            attributes_hash[:width])}w"}.join(", ")
         end
-        #remove now unnecessary tags
-        attributes_hash.delete(:height)
-        attributes_hash.delete(:width)
       end
       attributes_hash
+    end
+
+    private
+    def calculate_resulting_width(srcset_option, original_picture_width)
+      srcset_option = srcset_option[0...-1]
+      result = original_picture_width*srcset_option.to_f
+      result.to_i
     end
 
   end

--- a/app/helpers/sinicum/mgnl_image_helper.rb
+++ b/app/helpers/sinicum/mgnl_image_helper.rb
@@ -23,7 +23,7 @@ module Sinicum
           options.delete(attribute)
         end
         add_missing_attributes(attributes, options)
-        add_srcset(attributes)
+        configure_for_srcset(attributes)
         attributes
       end
     end

--- a/spec/fixtures/imaging_with_srcset.yml
+++ b/spec/fixtures/imaging_with_srcset.yml
@@ -32,3 +32,11 @@ renderer:
     format: jpeg
     x: 960
     y: 444
+
+  etc:
+    render_type: resize_max
+    format: jpeg
+    x: 300
+    y: 500
+
+

--- a/spec/helpers/sinicum/helper_utils_spec.rb
+++ b/spec/helpers/sinicum/helper_utils_spec.rb
@@ -51,7 +51,7 @@ module Sinicum
       end
     end
 
-    describe "#add_srcset" do
+    describe "#configure_for_srcset" do
       context "with srcset defined" do
         test_config = File.join(File.dirname(__FILE__), "../../fixtures/imaging_with_srcset.yml")
         let(:config) { Sinicum::Imaging::Config.configure(test_config) }
@@ -59,16 +59,16 @@ module Sinicum
         it "should add srcset tags to attributes" do
           tag_with_srcset = {
             src: "/damfiles/etc/pp/hero-teaser-cruises-1e531d3c7476f916d42215fd2f829839.jpg",
-            alt: "hero-teaser-cruises", width: 1920, height: 480, class: "slide-img",
-            srcset: "/damfiles/etc/pp/hero-teaser-cruises_050-1e531d3c7476f916d42215fd2f829839.jpg 0.5x," \
-            " /damfiles/etc/pp/hero-teaser-cruises_150-1e531d3c7476f916d42215fd2f829839.jpg 1.5x," \
-            " /damfiles/etc/pp/hero-teaser-cruises_175-1e531d3c7476f916d42215fd2f829839.jpg 1.75x," \
-            " /damfiles/etc/pp/hero-teaser-cruises_200-1e531d3c7476f916d42215fd2f829839.jpg 2x"
+            alt: "hero-teaser-cruises", class: "slide-img",
+            srcset: "/damfiles/etc/pp/hero-teaser-cruises_050-1e531d3c7476f916d42215fd2f829839.jpg 150w," \
+            " /damfiles/etc/pp/hero-teaser-cruises_150-1e531d3c7476f916d42215fd2f829839.jpg 450w," \
+            " /damfiles/etc/pp/hero-teaser-cruises_175-1e531d3c7476f916d42215fd2f829839.jpg 525w," \
+            " /damfiles/etc/pp/hero-teaser-cruises_200-1e531d3c7476f916d42215fd2f829839.jpg 600w"
           }
           allow(Sinicum::Imaging::Config).to receive(:read_configuration).and_return(config)
-          expect(helper.send(:add_srcset,
+          expect(helper.send(:configure_for_srcset,
             { src: "/damfiles/etc/pp/hero-teaser-cruises-1e531d3c7476f916d42215fd2f829839.jpg",
-              alt: "hero-teaser-cruises", width: 1920, height: 480, class: "slide-img" }
+              alt: "hero-teaser-cruises", class: "slide-img" }
           )).to eq(tag_with_srcset)
         end
       end
@@ -84,7 +84,7 @@ module Sinicum
           }
           allow(helper).to receive(:loaded_srcset_options).and_return([])
           expect(helper.send(
-            :add_srcset,
+            :configure_for_srcset,
             {src: "/damfiles/etc/pp/hero-teaser-cruises-1e531d3c7476f916d42215fd2f829839.jpg", alt: "hero-teaser-cruises", width: 1920, height: 480, class: "slide-img"}
           )).to eq(img_tag)
         end

--- a/spec/helpers/sinicum/helper_utils_spec.rb
+++ b/spec/helpers/sinicum/helper_utils_spec.rb
@@ -59,7 +59,7 @@ module Sinicum
         it "should add srcset tags to attributes" do
           tag_with_srcset = {
             src: "/damfiles/etc/pp/hero-teaser-cruises-1e531d3c7476f916d42215fd2f829839.jpg",
-            alt: "hero-teaser-cruises", class: "slide-img",
+            alt: "hero-teaser-cruises", width: 300, height: 500, class: "slide-img",
             srcset: "/damfiles/etc/pp/hero-teaser-cruises_050-1e531d3c7476f916d42215fd2f829839.jpg 150w," \
             " /damfiles/etc/pp/hero-teaser-cruises_150-1e531d3c7476f916d42215fd2f829839.jpg 450w," \
             " /damfiles/etc/pp/hero-teaser-cruises_175-1e531d3c7476f916d42215fd2f829839.jpg 525w," \
@@ -68,7 +68,7 @@ module Sinicum
           allow(Sinicum::Imaging::Config).to receive(:read_configuration).and_return(config)
           expect(helper.send(:configure_for_srcset,
             { src: "/damfiles/etc/pp/hero-teaser-cruises-1e531d3c7476f916d42215fd2f829839.jpg",
-              alt: "hero-teaser-cruises", class: "slide-img" }
+              alt: "hero-teaser-cruises", width: 300, height: 500, class: "slide-img" }
           )).to eq(tag_with_srcset)
         end
       end
@@ -80,12 +80,12 @@ module Sinicum
         it "should not add srcset tags to attributes" do
           img_tag = {
             src: "/damfiles/etc/pp/hero-teaser-cruises-1e531d3c7476f916d42215fd2f829839.jpg",
-            alt: "hero-teaser-cruises", width: 1920, height: 480, class: "slide-img"
+            alt: "hero-teaser-cruises", width: 300, height: 500, class: "slide-img"
           }
           allow(helper).to receive(:loaded_srcset_options).and_return([])
           expect(helper.send(
             :configure_for_srcset,
-            {src: "/damfiles/etc/pp/hero-teaser-cruises-1e531d3c7476f916d42215fd2f829839.jpg", alt: "hero-teaser-cruises", width: 1920, height: 480, class: "slide-img"}
+            {src: "/damfiles/etc/pp/hero-teaser-cruises-1e531d3c7476f916d42215fd2f829839.jpg", alt: "hero-teaser-cruises", width: 300, height: 500, class: "slide-img"}
           )).to eq(img_tag)
         end
       end


### PR DESCRIPTION
Srcset has changed from pixel density to picture width
-increased browser flexibility(downscaling of picture now possible)
-includes the features of pixel density

e.g. from
```
<img src="one.png"  
     srcset="two.png 2x, three.png 3x, four.png 4x">
```

to:
```
<img src="one.png"  
     srcset="two.png 100w, three.png 500w, four.png 1000w">
```