### PR TITLE
Generate srcset links only for correct inputs

### DIFF
--- a/app/helpers/sinicum/helper_utils.rb
+++ b/app/helpers/sinicum/helper_utils.rb
@@ -152,7 +152,7 @@ module Sinicum
     def configure_for_srcset(attributes_hash)
       srcset_options = Sinicum::Imaging::Config.read_configuration.srcset_options
       if srcset_options.present?
-        if match = attributes_hash[:src].match(/(.+?)-(\h{32})(\.\w+)?$/)
+        if (match = attributes_hash[:src].match(/(.+?)-(\h{32})(\.\w+)?$/)) && attributes_hash[:width].is_a?(Numeric)
           attributes_hash[:srcset] = srcset_options.map { |e|  \
             "#{match[1]}_#{e[0]}-#{match[2]}#{match[3]} #{calculate_resulting_width(e[1],
             attributes_hash[:width])}w"}.join(", ")

--- a/app/helpers/sinicum/helper_utils.rb
+++ b/app/helpers/sinicum/helper_utils.rb
@@ -152,7 +152,8 @@ module Sinicum
     def configure_for_srcset(attributes_hash)
       srcset_options = Sinicum::Imaging::Config.read_configuration.srcset_options
       if srcset_options.present?
-        if (match = attributes_hash[:src].match(/(.+?)-(\h{32})(\.\w+)?$/)) && attributes_hash[:width].is_a?(Numeric)
+        if (match = attributes_hash[:src].match(/(.+?)-(\h{32})(\.\w+)?$/)) &&
+         attributes_hash[:width].is_a?(Numeric)
           attributes_hash[:srcset] = srcset_options.map { |e|  \
             "#{match[1]}_#{e[0]}-#{match[2]}#{match[3]} #{calculate_resulting_width(e[1],
             attributes_hash[:width])}w"}.join(", ")

--- a/spec/helpers/sinicum/helper_utils_spec.rb
+++ b/spec/helpers/sinicum/helper_utils_spec.rb
@@ -71,6 +71,30 @@ module Sinicum
               alt: "hero-teaser-cruises", width: 300, height: 500, class: "slide-img" }
           )).to eq(tag_with_srcset)
         end
+
+        it "should do nothing if width is missing" do
+          tag_with_srcset = {
+            src: "/damfiles/etc/pp/hero-teaser-cruises-1e531d3c7476f916d42215fd2f829839.jpg",
+            alt: "hero-teaser-cruises", height: 500, class: "slide-img",
+          }
+          allow(Sinicum::Imaging::Config).to receive(:read_configuration).and_return(config)
+          expect(helper.send(:configure_for_srcset,
+            { src: "/damfiles/etc/pp/hero-teaser-cruises-1e531d3c7476f916d42215fd2f829839.jpg",
+              alt: "hero-teaser-cruises", height: 500, class: "slide-img" }
+          )).to eq(tag_with_srcset)
+        end
+
+        it "should do nothing if width is not a number" do
+          tag_with_srcset = {
+            src: "/damfiles/etc/pp/hero-teaser-cruises-1e531d3c7476f916d42215fd2f829839.jpg",
+            alt: "hero-teaser-cruises", width: "300x", height: 500, class: "slide-img",
+          }
+          allow(Sinicum::Imaging::Config).to receive(:read_configuration).and_return(config)
+          expect(helper.send(:configure_for_srcset,
+            { src: "/damfiles/etc/pp/hero-teaser-cruises-1e531d3c7476f916d42215fd2f829839.jpg",
+              alt: "hero-teaser-cruises", width: "300x", height: 500, class: "slide-img" }
+          )).to eq(tag_with_srcset)
+        end
       end
 
       context "without srcset defined" do


### PR DESCRIPTION
In some occasions no width-tag can be found in the html code. Prevent generation of srcset tags in those cases.
