### PR TITLE
Permanent redirects should be possible too

### DIFF
--- a/app/controllers/sinicum/controller_base.rb
+++ b/app/controllers/sinicum/controller_base.rb
@@ -104,10 +104,11 @@ module Sinicum
       page = ::Sinicum::Content::Aggregator.content_data
       if redirect_page_45?(page) || redirect_page_44?(page)
         redirect_target = page[:redirect_link]
+        redirect_status = page[:redirect_status] || 302
         if Sinicum::Util.is_a_uuid?(redirect_target)
           redirect_target = Sinicum::Jcr::Node.find_by_uuid("website", redirect_target).try(:path)
         end
-        redirect_to redirect_target
+        redirect_to redirect_target, status: redirect_status
         return true
       end
       return false

--- a/spec/controllers/sinicum/controller_base_spec.rb
+++ b/spec/controllers/sinicum/controller_base_spec.rb
@@ -4,7 +4,7 @@ module Sinicum
   describe ApplicationController do
     let(:node) { Jcr::Node.new }
 
-    before(:each) do
+    before(:example) do
       allow(Content::Aggregator).to receive(:original_content).and_return(node)
       allow(Content::WebsiteContentResolver).to receive(:find_for_path).and_return(node)
       allow(node).to receive(:mgnl_template).and_return("something")
@@ -23,6 +23,41 @@ module Sinicum
     it "should ignore post requests" do
       post :index, format: "html"
       expect(response.status).to eq(200)
+    end
+
+    describe "redirects" do
+      it "should redirect with 302 if no status is set" do
+        redirect_node = Jcr::Node.new({ redirect_link: "http://www.dievision.de/redirect_link" })
+        allow(redirect_node).to receive(:mgnl_template).and_return("my-module:pages/redirect")
+        allow(Content::Aggregator).to receive(:original_content).and_return(redirect_node)
+
+        get :index
+
+        expect(response).to redirect_to("http://www.dievision.de/redirect_link")
+        expect(response.code).to eq("302")
+      end
+
+      it "should redirect with 302 if set" do
+        redirect_node = Jcr::Node.new({ redirect_link: "http://www.dievision.de/redirect_link", redirect_status: "302" })
+        allow(redirect_node).to receive(:mgnl_template).and_return("my-module:pages/redirect")
+        allow(Content::Aggregator).to receive(:original_content).and_return(redirect_node)
+
+        get :index
+
+        expect(response).to redirect_to("http://www.dievision.de/redirect_link")
+        expect(response.code).to eq("302")
+      end
+
+      it "should redirect with 301 if set" do
+        redirect_node = Jcr::Node.new({ redirect_link: "http://www.dievision.de/redirect_link", redirect_status: 301 })
+        allow(redirect_node).to receive(:mgnl_template).and_return("my-module:pages/redirect")
+        allow(Content::Aggregator).to receive(:original_content).and_return(redirect_node)
+
+        get :index
+
+        expect(response).to redirect_to("http://www.dievision.de/redirect_link")
+        expect(response.code).to eq("301")
+      end
     end
 
     describe "layout" do
@@ -47,13 +82,6 @@ module Sinicum
         allow(node).to receive(:mgnl_template).and_return("my-module:pages/test")
         get :index
         expect(response).to render_template("my-module/test")
-      end
-
-      it "should handle the redirect template" do
-        allow(node).to receive(:mgnl_template).and_return("my-module:pages/redirect")
-        allow(node).to receive(:[]).with(:redirect_link).and_return("/en/root")
-        get :index
-        expect(response).to redirect_to("/en/root")
       end
     end
   end


### PR DESCRIPTION
With this change, a `redirect_status` property can be added to the redirect template, which will trigger a permanent redirect.

Of course backwards compatible... the standard will still be 302.