### PR TITLE
Default quality of 80 should be the best way

### DIFF
--- a/lib/sinicum/imaging/converter.rb
+++ b/lib/sinicum/imaging/converter.rb
@@ -55,7 +55,7 @@ module Sinicum
       end
 
       def quality_option
-        "-quality 80" if @hires_factor && @hires_factor > 1.5
+        "-quality 80"
       end
 
       def optimize_png_outfile(outfile_path, extension)


### PR DESCRIPTION
From the imagemagick documentation:

`The default is to use the estimated quality of your input image if it can be determined, otherwise 92. When the quality is greater than 90, then the chroma channels are not downsampled. `

I think a default value of 80 gives the best compromise between quality and size. This should be used *all* the time and not only for `hires_factor > 1.5`.