### PR TITLE
Use the globalstatecache only, when the request has the status code 200

### DIFF
--- a/app/controllers/sinicum/controllers/global_state_cache.rb
+++ b/app/controllers/sinicum/controllers/global_state_cache.rb
@@ -32,7 +32,7 @@ module Sinicum
 
       def render_or_proceed
         cached = Rails.cache.fetch(cache_key)
-        if cached && cached[:status].to_s != "302"
+        if cached && cached[:status].to_s == "200"
           @controller.response.cache_control.merge!(cached[:cache_control])
           @controller.response.status = cached[:status]
           @controller.response.headers["X-SCache"] = "true"


### PR DESCRIPTION
Since we now support 301 redirects too, a check for a status of `200` is more straightforward.