### PR TITLE
Component Whitelist

### DIFF
--- a/app/helpers/sinicum/taglib_helper5.rb
+++ b/app/helpers/sinicum/taglib_helper5.rb
@@ -25,6 +25,9 @@ module Sinicum
       result = nil
       if area_name.present?
         available_components = initialize_area(mgnl_content_data, area_name)
+        if options[:component_whitelist]
+          available_components = available_components & options[:component_whitelist]
+        end
         if available_components
           result = mgnl_comment_tag(
             :'cms:area',


### PR DESCRIPTION
Small adjustment, but big impact:

We can now filter the components, that will be shown in the dropdown in Magnolia - and we can adjust this filter depending on basically everything: specific parts of the website, locales, variables etc.