### PR TITLE
Navigationhandler is more robust

### DIFF
--- a/lib/sinicum/navigation/navigation_element_list.rb
+++ b/lib/sinicum/navigation/navigation_element_list.rb
@@ -5,11 +5,12 @@ module Sinicum
     class NavigationElementList
       include Enumerable
 
-      def initialize(navigation_elements)
+      def initialize(navigation_elements = [])
         @navigation_elements = navigation_elements
       end
 
       def each(&block)
+        return if empty?
         count = 0
         @navigation_elements.each do |el|
           block.call(el, NavigationStatus.new(@navigation_elements.size, count))
@@ -18,7 +19,7 @@ module Sinicum
       end
 
       def size
-        @navigation_elements.size
+        @navigation_elements.size || 0
       end
 
       def first
@@ -27,6 +28,10 @@ module Sinicum
 
       def last
         @navigation_elements.last
+      end
+
+      def empty?
+        size == 0
       end
     end
   end

--- a/lib/sinicum/navigation/navigation_handler.rb
+++ b/lib/sinicum/navigation/navigation_handler.rb
@@ -38,6 +38,8 @@ module Sinicum
         if result.ok?
           json = MultiJson.load(result.body)
           initialize_from_json(json)
+        else
+          []
         end
       end
 
@@ -48,6 +50,8 @@ module Sinicum
         if result.ok?
           json = MultiJson.load(result.body)
           initialize_from_json(json)
+        else
+          []
         end
       end
 


### PR DESCRIPTION
... and it should behave more like an Enumerable and not crash, if a wrong path is given for the navigation.