### PR TITLE
Bugfix for calling a folder

### DIFF
--- a/lib/sinicum/imaging/imaging.rb
+++ b/lib/sinicum/imaging/imaging.rb
@@ -75,7 +75,7 @@ module Sinicum
       def find_image_objects_by_path(original_path)
         result = [nil, nil]
         image = Sinicum::Jcr::Node.find_by_path(@workspace, original_path)
-        if image
+        if image && image.kind_of? Sinicum::Jcr::Dam::Document
           doc = image.properties
           result = [image, doc]
         end

--- a/lib/sinicum/imaging/imaging.rb
+++ b/lib/sinicum/imaging/imaging.rb
@@ -75,7 +75,7 @@ module Sinicum
       def find_image_objects_by_path(original_path)
         result = [nil, nil]
         image = Sinicum::Jcr::Node.find_by_path(@workspace, original_path)
-        if image && image.kind_of? Sinicum::Jcr::Dam::Document
+        if image && image.kind_of?(Sinicum::Jcr::Dam::Document)
           doc = image.properties
           result = [image, doc]
         end


### PR DESCRIPTION
Let's say we have an image:
`www.example.com/damfiles/default/header_images/image001.jpg`

If you call `www.example.com/damfiles/default/header_images/` it would throw an exception. This is fixed now.