### PR TITLE
Ao anchor for internal link in redirect templates

### DIFF
--- a/app/controllers/sinicum/controller_base.rb
+++ b/app/controllers/sinicum/controller_base.rb
@@ -106,7 +106,7 @@ module Sinicum
         redirect_target = page[:redirect_link] || page[:external_redirect_link]
         if Sinicum::Util.is_a_uuid?(redirect_target)
           redirect_target = Sinicum::Jcr::Node.find_by_uuid("website", redirect_target).try(:path)
-          redirect_target << page[:anchor].presence || ""
+          redirect_target << page[:anchor].presence || "" if redirect_target.present?
         end
         redirect_to url_for(redirect_target)
         return true

--- a/app/controllers/sinicum/controller_base.rb
+++ b/app/controllers/sinicum/controller_base.rb
@@ -106,7 +106,7 @@ module Sinicum
         redirect_target = page[:redirect_link] || page[:external_redirect_link]
         if Sinicum::Util.is_a_uuid?(redirect_target)
           redirect_target = Sinicum::Jcr::Node.find_by_uuid("website", redirect_target).try(:path)
-          redirect_target << page[:anchor].presence || "" if redirect_target.present?
+          redirect_target = "#{redirect_target}#{page[:anchor].presence || ''}" if redirect_target
         end
         redirect_to url_for(redirect_target)
         return true

--- a/app/controllers/sinicum/controller_base.rb
+++ b/app/controllers/sinicum/controller_base.rb
@@ -106,7 +106,9 @@ module Sinicum
         redirect_target = page[:redirect_link] || page[:external_redirect_link]
         if Sinicum::Util.is_a_uuid?(redirect_target)
           redirect_target = Sinicum::Jcr::Node.find_by_uuid("website", redirect_target).try(:path)
-          redirect_target = "#{redirect_target}#{page[:anchor].presence || ''}" if redirect_target
+          if redirect_target && page[:anchor].present?
+            redirect_target = "#{redirect_target}#{page[:anchor]}"
+          end
         end
         redirect_to url_for(redirect_target)
         return true

--- a/app/controllers/sinicum/controller_base.rb
+++ b/app/controllers/sinicum/controller_base.rb
@@ -106,6 +106,7 @@ module Sinicum
         redirect_target = page[:redirect_link] || page[:external_redirect_link]
         if Sinicum::Util.is_a_uuid?(redirect_target)
           redirect_target = Sinicum::Jcr::Node.find_by_uuid("website", redirect_target).try(:path)
+          redirect_target << page[:anchor].presence || ""
         end
         redirect_to url_for(redirect_target)
         return true

--- a/spec/controllers/sinicum/controller_base_spec.rb
+++ b/spec/controllers/sinicum/controller_base_spec.rb
@@ -49,11 +49,45 @@ module Sinicum
         expect(response).to render_template("my-module/test")
       end
 
-      it "should handle the redirect template" do
-        allow(node).to receive(:mgnl_template).and_return("my-module:pages/redirect")
-        allow(node).to receive(:[]).with(:redirect_link).and_return("/en/root")
-        get :index
-        expect(response).to redirect_to("/en/root")
+      describe "redirect template" do
+        it "should redirect to the :redirect_link property as an external link" do
+          allow(node).to receive(:mgnl_template).and_return("my-module:pages/redirect")
+          allow(node).to receive(:[]).with(:redirect_link).and_return("/en/root")
+          get :index
+          expect(response).to redirect_to("/en/root")
+        end
+
+        it "should redirect to the :redirect_link property as an internal link" do
+          allow(node).to receive(:mgnl_template).and_return("my-module:pages/redirect")
+          allow(node).to receive(:[]).with(:redirect_link).and_return("/en/root")
+          get :index
+          expect(response).to redirect_to("/en/root")
+        end
+
+        it "should redirect to the :redirect_link prior to the :external_redirect_link" do
+          allow(node).to receive(:mgnl_template).and_return("my-module:pages/redirect")
+          allow(node).to receive(:[]).with(:redirect_link).and_return("/en/root")
+          allow(node).to receive(:[]).with(:external_redirect_link).and_return("http://www.web.com")
+          get :index
+          expect(response).to redirect_to("/en/root")
+        end
+
+        it "should redirect to the :external_redirect_link property if no :redirect_link" do
+          allow(node).to receive(:mgnl_template).and_return("my-module:pages/redirect")
+          allow(node).to receive(:[]).with(:redirect_link).and_return(nil)
+          allow(node).to receive(:[]).with(:external_redirect_link).and_return("http://www.web.com")
+          get :index
+          expect(response).to redirect_to("http://www.web.com")
+        end
+
+        it "should ignore the anchor for external link" do
+          allow(node).to receive(:mgnl_template).and_return("my-module:pages/redirect")
+          allow(node).to receive(:[]).with(:redirect_link).and_return(nil)
+          allow(node).to receive(:[]).with(:external_redirect_link).and_return("http://www.web.com")
+          allow(node).to receive(:[]).with(:anchor).and_return("#123456abcdef")
+          get :index
+          expect(response).to redirect_to("http://www.web.com")
+        end
       end
     end
   end


### PR DESCRIPTION
Possibility to add an Anchor to internal `:redirect_link` path for the Magnolia Redirect Templates.