### PR TITLE
Getting rid of the splat operator in order to enable custom headers

### DIFF
--- a/lib/sinicum/jcr/api_client.rb
+++ b/lib/sinicum/jcr/api_client.rb
@@ -2,18 +2,18 @@ module Sinicum
   module Jcr
     module ApiClient
       include ::Sinicum::Logger
-      def api_get(path, *args, &block)
+      def api_get(path, args = nil, &block)
         full_path = api_full_path(URI.escape(path))
         log_get_path(full_path, args)
 
-        instrumentation_query = args[0] && args[0]["query"] ? args[0]["query"] : path
+        instrumentation_query = args && args["query"] ? args["query"] : path
 
         ActiveSupport::Notifications.instrument(
           "jcr_query.sinicum",
           query: instrumentation_query,
           context: "Sinicum API GET:") do
           start = Time.now
-          result = ApiQueries.http_client.get(full_path, *args, &block)
+          result = ApiQueries.http_client.get(full_path, args, &block)
           elapsed_time = ((Time.now - start).to_f * 1000).round(1)
           logger.debug("      Completed request in #{elapsed_time}ms")
           result
@@ -36,8 +36,8 @@ module Sinicum
 
       def log_get_path(full_path, args)
         log = "    Sinicum API GET: " + full_path
-        if args[0] && args[0].respond_to?(:[])
-          log << "\n      Parameters (Query): " + args[0].inspect
+        if args && args.respond_to?(:[])
+          log << "\n      Parameters (Query): " + args.inspect
         end
         logger.debug(log)
       end

--- a/lib/sinicum/jcr/api_client.rb
+++ b/lib/sinicum/jcr/api_client.rb
@@ -13,7 +13,7 @@ module Sinicum
           query: instrumentation_query,
           context: "Sinicum API GET:") do
           start = Time.now
-          result = ApiQueries.http_client.get(full_path, args, &block)
+          result = ApiQueries.http_client.get(full_path, args, additional_headers, &block)
           elapsed_time = ((Time.now - start).to_f * 1000).round(1)
           logger.debug("      Completed request in #{elapsed_time}ms")
           result
@@ -33,9 +33,17 @@ module Sinicum
       end
 
       private
+      def additional_headers
+        if Thread.current["__sinicum_additional_headers"] &&
+          Thread.current["__sinicum_additional_headers"].is_a?(Hash)
+          Thread.current["__sinicum_additional_headers"]
+        else
+          {}
+        end
+      end
 
       def log_get_path(full_path, args)
-        log = "    Sinicum API GET: " + full_path
+        log = "    Sinicum API GET: Ω" + full_path
         if args && args.respond_to?(:[])
           log << "\n      Parameters (Query): " + args.inspect
         end

--- a/spec/sinicum/jcr/api_client_spec.rb
+++ b/spec/sinicum/jcr/api_client_spec.rb
@@ -35,9 +35,9 @@ module Sinicum
 
           expect(ApiQueries).to receive(:http_client).and_return(http_client)
           expect(http_client).to receive(:get).with(
-            client_base_url + path, query).and_return(response)
+            client_base_url + path, query, {}).and_return(response)
 
-          subject.api_get(path, query, {})
+          subject.api_get(path, query)
         end
 
         it "should escape a path" do

--- a/spec/sinicum/jcr/api_client_spec.rb
+++ b/spec/sinicum/jcr/api_client_spec.rb
@@ -24,7 +24,7 @@ module Sinicum
 
           expect(ApiQueries).to receive(:http_client).and_return(http_client)
           expect(http_client).to receive(:get).with(
-            client_base_url + path).and_return(response)
+            client_base_url + path, nil, {}).and_return(response)
 
           subject.api_get(path)
         end
@@ -37,7 +37,7 @@ module Sinicum
           expect(http_client).to receive(:get).with(
             client_base_url + path, query).and_return(response)
 
-          subject.api_get(path, query)
+          subject.api_get(path, query, {})
         end
 
         it "should escape a path" do
@@ -45,7 +45,7 @@ module Sinicum
 
           expect(ApiQueries).to receive(:http_client).and_return(http_client)
           expect(http_client).to receive(:get).with(
-            client_base_url + URI.escape(path)).and_return(response)
+            client_base_url + URI.escape(path), nil, {}).and_return(response)
 
           subject.api_get(path)
         end


### PR DESCRIPTION
The splat operator is not needed anymore. It was removed in order to enable setting custom headers. 